### PR TITLE
Null-check server connection in ClientEventHandler#onClientTick

### DIFF
--- a/src/main/java/auviotre/enigmatic/legacy/client/handlers/ClientEventHandler.java
+++ b/src/main/java/auviotre/enigmatic/legacy/client/handlers/ClientEventHandler.java
@@ -128,6 +128,8 @@ public class ClientEventHandler {
 
     @SubscribeEvent
     private static void onClientTick(ClientTickEvent.Pre event) {
+        if (Minecraft.getInstance().getConnection() == null) return;
+
         LocalPlayer player = Minecraft.getInstance().player;
         if (!ISpellstone.get(player).isEmpty() && KeyHandler.SPELLSTONE.get().consumeClick())
             PacketDistributor.sendToServer(new SpellstoneKeyPacket());


### PR DESCRIPTION
Fixes a weird crash I was getting when entering a world name on the world creation screen